### PR TITLE
ignore disabled failed builds

### DIFF
--- a/src/jenkins/services/jenkins.service.ts
+++ b/src/jenkins/services/jenkins.service.ts
@@ -86,7 +86,6 @@ export class JenkinsService {
   }
 
   private includeJob(job) {
-    console.log('job', job);
     const jobName = job.name;
     const jobType = jobName.substring(jobName.indexOf('_') + 1, jobName.length);
     const jobNameToBuildName = jobName.substring(0, jobName.indexOf('_'));


### PR DESCRIPTION
addresses: https://github.com/blackbaud/mf-action-board/issues/30

also refactor a bit
LUM-21372

@blackbaud/micro-cervezas @Blackbaud-IsaacAggrey 

This should ignore the disabled builds we are seeing as action items, also did a light refactoring of the job inclusion logic.