### PR TITLE
upgrade bootstrap to avoid vulnerability warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",
-    "bootstrap": "3.3.7",
+    "bootstrap": "4.1.3",
     "core-js": "^2.4.1",
     "font-awesome": "4.7.0",
     "moment": "^2.0.0",

--- a/src/app/action-list/action-list.component.html
+++ b/src/app/action-list/action-list.component.html
@@ -1,11 +1,12 @@
 <div class="col-md-12 row labelBar">
   <div class="col-md-1" id="team-name">
-    <span class="label label-default">{{team}}</span>
+    <span class="badge badge-dark">{{team}}</span>
   </div>
   <div class="col-md-10"></div>
   <div class="col-md-1">
-    <span class="label label-default" *ngIf="loading">
-      <i class="fa fa-spinner">Loading</i>
+    <span class="badge badge-dark" *ngIf="loading">
+      <i class="fa fa-spinner fa-spin"></i>
+      Loading
     </span>
   </div>
 </div>

--- a/src/app/build/build.component.css
+++ b/src/app/build/build.component.css
@@ -39,7 +39,6 @@
 }
 
 .icon {
-  padding-right: 20px;
   text-shadow: 2px 2px 5px black;
 }
 
@@ -72,4 +71,8 @@
 
 .progress-bar{
   background-color: grey;
+}
+
+.col {
+  text-align: center;
 }

--- a/src/app/build/build.component.html
+++ b/src/app/build/build.component.html
@@ -1,12 +1,12 @@
 <div class="col-sm-12 action-item-panel buffer"
       [ngClass]="priorityClass">
   <a href="{{ build.url }}" target="_blank">
-    <div class="action-item-content">
-      <div class="col-sm-1">
+    <div class="action-item-content row">
+      <div class="col">
         <i *ngIf="build.type === 'build'" class="icon fa fa-server fa-4x"></i>
-        <i *ngIf="build.type === 'release'" class="icon fa fa-truck fa-flip-horizontal fa-4x"></i>
+        <i *ngIf="build.type === 'release'" class="icon fa fa-truck fa-4x"></i>
       </div>
-      <div class="action-item-text col-sm-10">{{ build.name }}
+      <div class="action-item-text col-10">{{ build.name }}
         <div class="time-elapsed-and-progress-bar-wrapper">
           <div class="time-elapsed-in-wrapper">{{ getTimeElapsed(build.created) }}
           </div>
@@ -15,7 +15,7 @@
           </div>
         </div>
       </div>
-      <div class="col-sm-1">
+      <div class="col">
         <mf-rage-face [priority]="build.priority"></mf-rage-face>
       </div>
     </div>

--- a/src/app/config-screen/config-screen.component.css
+++ b/src/app/config-screen/config-screen.component.css
@@ -1,0 +1,3 @@
+.config-cards {
+  margin-bottom: 10px;
+}

--- a/src/app/config-screen/config-screen.component.html
+++ b/src/app/config-screen/config-screen.component.html
@@ -1,85 +1,81 @@
-<div class="container-fluid">
-
-  <div class="col-md-10 col-md-offset-1 row">
-    <div class="col-md-6">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          <h3 class="panel-title">
-            <i class="icon fa fa-github"></i>
-            GitHub Config
-            <span *ngIf="configService.github.isConfigured()" class="label label-success">Valid Input</span>
-            <span *ngIf="!configService.github.isConfigured()" class="label label-danger">Invalid Input</span>
-          </h3>
+<div class="row">
+  <div class="col-10 offset-1 row config-cards">
+    <div class="col-6">
+      <div class="card">
+        <div class="card-header">
+          <i class="icon fa fa-github"></i>
+          GitHub Config
+          <span *ngIf="configService.github.isConfigured()" class="badge badge-success">Valid Input</span>
+          <span *ngIf="!configService.github.isConfigured()" class="badge badge-danger">Invalid Input</span>
         </div>
-        <div class="panel-body">
+        <div class="card-body">
           <div class="form-group">
             <label>Team Name</label>
             <input type="text" class="form-control input-lg"
-              [ngModel]="getGitHubConfigValue('team')" (ngModelChange)="setGitHubConfigValue('team', $event)" />
+                   [ngModel]="getGitHubConfigValue('team')" (ngModelChange)="setGitHubConfigValue('team', $event)"/>
           </div>
           <div class="form-group">
             <label>Team Id</label>
             <input type="text" class="form-control input-lg"
-              [ngModel]="getGitHubConfigValue('teamId')" (ngModelChange)="setGitHubConfigValue('teamId', $event)" />
+                   [ngModel]="getGitHubConfigValue('teamId')" (ngModelChange)="setGitHubConfigValue('teamId', $event)"/>
           </div>
           <div class="form-group">
             <label>User Name</label>
             <input type="text" class="form-control input-lg"
-              [ngModel]="getGitHubConfigValue('userName')" (ngModelChange)="setGitHubConfigValue('userName', $event)" />
+                   [ngModel]="getGitHubConfigValue('userName')"
+                   (ngModelChange)="setGitHubConfigValue('userName', $event)"/>
           </div>
           <div class="form-group">
             <label>Token</label>
             <input type="text" class="form-control input-lg"
-              [ngModel]="getGitHubConfigValue('token')" (ngModelChange)="setGitHubConfigValue('token', $event)" />
+                   [ngModel]="getGitHubConfigValue('token')" (ngModelChange)="setGitHubConfigValue('token', $event)"/>
           </div>
           <div class="form-group">
             <label>Watch Repos</label>
             <input type="text" class="form-control input-lg"
-                   [ngModel]="getGitHubConfigValue('watchList')" (ngModelChange)="setGitHubConfigValue('watchList', $event)" />
+                   [ngModel]="getGitHubConfigValue('watchList')"
+                   (ngModelChange)="setGitHubConfigValue('watchList', $event)"/>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="col-md-6">
-    <div class="panel panel-primary">
-      <div class="panel-heading">
-        <h3 class="panel-title">
+    <div class="col-6">
+      <div class="card">
+        <div class="card-header">
           <i class="icon fa fa-windows"></i>
           VSTS Config
-          <span *ngIf="configService.vsts.isConfigured()" class="label label-success">Valid Input</span>
-          <span *ngIf="!configService.vsts.isConfigured()" class="label label-danger">Invalid Input</span>
-        </h3>
-      </div>
-      <div class="panel-body">
-        <div class="form-group">
-          <label>Team Name</label>
-          <select class="form-control input-lg"
-            [ngModel]="getVstsConfigValue('team')" (ngModelChange)="setVstsConfigValue('team', $event)">
-            <option *ngFor="let team of teams" [ngValue]="team">{{team}}</option>
-          </select>
+          <span *ngIf="configService.vsts.isConfigured()" class="badge badge-success">Valid Input</span>
+          <span *ngIf="!configService.vsts.isConfigured()" class="badge badge-danger">Invalid Input</span>
         </div>
-        <div class="form-group">
-          <label>User Name</label>
-          <input type="text" class="form-control input-lg" placeholder="first.last@blackbaud.me"
-            [ngModel]="getVstsConfigValue('username')" (ngModelChange)="setVstsConfigValue('username', $event)" />
-        </div>
-        <div class="form-group">
-          <label>Token</label>
-          <input type="text" class="form-control input-lg"
-            [ngModel]="getVstsConfigValue('token')" (ngModelChange)="setVstsConfigValue('token', $event)" />
+        <div class="card-body">
+          <div class="form-group">
+            <label>Team Name</label>
+            <select class="form-control input-lg"
+                    [ngModel]="getVstsConfigValue('team')" (ngModelChange)="setVstsConfigValue('team', $event)">
+              <option *ngFor="let team of teams" [ngValue]="team">{{team}}</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label>User Name</label>
+            <input type="text" class="form-control input-lg" placeholder="first.last@blackbaud.me"
+                   [ngModel]="getVstsConfigValue('username')" (ngModelChange)="setVstsConfigValue('username', $event)"/>
+          </div>
+          <div class="form-group">
+            <label>Token</label>
+            <input type="text" class="form-control input-lg"
+                   [ngModel]="getVstsConfigValue('token')" (ngModelChange)="setVstsConfigValue('token', $event)"/>
+          </div>
         </div>
       </div>
     </div>
   </div>
-  </div>
+</div>
 
-
-  <div class="col-md-10 col-md-offset-1 row text-center">
-    <button type="button" class="btn btn-primary"
-      (click)="saveConfig()"
-      [ngClass]="{'disabled': !configService.isConfigured()}">
-      Save Configuration
-    </button>
-  </div>
+<div class="mx-auto text-center">
+  <button type="button" class="btn btn-primary"
+          (click)="saveConfig()"
+          [ngClass]="{'disabled': !configService.isConfigured()}">
+    Save Configuration
+  </button>
 </div>

--- a/src/app/pull-request/pull-request.component.css
+++ b/src/app/pull-request/pull-request.component.css
@@ -34,7 +34,6 @@
 }
 
 .icon {
-  padding-right: 20px;
   text-shadow: 2px 2px 5px black;
 }
 
@@ -47,4 +46,8 @@
 
 .time-elapsed {
   font-size: 20px;
+}
+
+.col {
+  text-align: center;
 }

--- a/src/app/pull-request/pull-request.component.html
+++ b/src/app/pull-request/pull-request.component.html
@@ -1,11 +1,13 @@
 <div class="col-sm-12 action-item-panel buffer" [ngClass]="priorityClass">
   <a href="{{pr.url}}" target="_blank">
-    <div class="action-item-content">
-      <div class="col-sm-1"><i class="icon fa fa-code-fork fa-4x"></i></div>
-      <div class="action-item-text col-sm-10">{{pr.name}}
+    <div class="action-item-content row">
+      <div class="col">
+        <i class="icon fa fa-code-fork fa-4x"></i>
+      </div>
+      <div class="action-item-text col-10">{{pr.name}}
         <div class="time-elapsed">{{getTimeElapsed(pr.created)}}</div>
       </div>
-      <div class="col-sm-1">
+      <div class="col">
         <mf-rage-face [priority]="pr.priority"></mf-rage-face>
       </div>
     </div>


### PR DESCRIPTION
specifically this one: https://nvd.nist.gov/vuln/detail/CVE-2018-14041

it seems to only affect the js portion of twbs, which we don't use, but
i was tired of seeing :octocat: warn me about it

to upgrade:
- use new grid system
- move panels to cards
- move labels to badges

and since i was in it, i also
- and made the icons line up better when there are diff types of action
  items

@blackbaud/micro-cervezas 


Before:
<img width="1435" alt="screen shot 2018-09-27 at 10 53 08 am" src="https://user-images.githubusercontent.com/28735029/46158861-6dc51f80-c244-11e8-9f4e-3180d663334e.png">

After:
<img width="1438" alt="screen shot 2018-09-27 at 11 21 25 am" src="https://user-images.githubusercontent.com/28735029/46160098-83881400-c247-11e8-8b04-914ae922af63.png">

Before:
<img width="1438" alt="screen shot 2018-09-27 at 10 53 28 am" src="https://user-images.githubusercontent.com/28735029/46160401-3eb0ad00-c248-11e8-91d2-70b30682fdef.png">

After:
<img width="1327" alt="screen shot 2018-09-27 at 11 44 40 am" src="https://user-images.githubusercontent.com/28735029/46161346-ed55ed00-c24a-11e8-8d9d-a078cc0346af.png">

